### PR TITLE
Ci - additional linting

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,10 @@
 name: build
 
+# Cancel concurrent jobs for the same ref
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 # Running CI on push for all branches and PRs
 on: ["push", "pull_request"]
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,8 +5,12 @@ concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 
-# Running CI on push for all branches and PRs
-on: ["push", "pull_request"]
+# Running CI on push to main and open PRs
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   golangci:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ jobs:
       name: lint
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
         - uses: actions/setup-go@v4
           with:
             go-version-file: go.mod
@@ -22,7 +22,7 @@ jobs:
       name: test
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
         - uses: actions/setup-go@v4
           with:
             go-version-file: go.mod

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,10 @@ jobs:
             go-version-file: go.mod
         - name: golangci-lint
           uses: golangci/golangci-lint-action@v3
-          with:
+          with:          
+            args: -E gosec -E goconst --issues-exit-code=0
+            skip-pkg-cache: true
+            skip-build-cache: true
             version: latest
   test:
       name: test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,10 +10,15 @@ jobs:
       name: lint
       runs-on: ubuntu-latest
       steps:
+        # Checkout the code
         - uses: actions/checkout@v4
+        
+        # setup Golang based on the go.mod version
         - uses: actions/setup-go@v4
           with:
             go-version-file: go.mod
+        
+        # run go ci lint to catch standard go issues
         - name: golangci-lint
           uses: golangci/golangci-lint-action@v3
           with:          
@@ -21,12 +26,22 @@ jobs:
             skip-pkg-cache: true
             skip-build-cache: true
             version: latest
+        
+        # Make sure the go mod is tidy
+        - run: go mod tidy && git diff --exit-code
+  
   test:
       name: test
       runs-on: ubuntu-latest
       steps:
+        
+        # Checkout the code
         - uses: actions/checkout@v4
+
+        # Setup Golang based on the go.mod version
         - uses: actions/setup-go@v4
           with:
             go-version-file: go.mod
+        
+        # Run the tests
         - run: go test ./... -v

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,6 +7,7 @@ jobs:
   golangci:
       name: lint
       runs-on: ubuntu-latest
+      timeout-minutes: 5
       steps:
         # Checkout the code
         - uses: actions/checkout@v4
@@ -31,6 +32,7 @@ jobs:
   test:
       name: test
       runs-on: ubuntu-latest
+      timeout-minutes: 5
       steps:
         
         # Checkout the code

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,9 +1,7 @@
 name: build
-on:
-  push:
-    branches:
-      - main
-  pull_request:
+
+# Running CI on push for all branches and PRs
+on: ["push", "pull_request"]
 
 jobs:
   golangci:


### PR DESCRIPTION
There is never enough linting :D

- Added comments to each step of the pipeline
- Checking if the go.mod is tidy
- Added `gosec` and `goconst` to the golangci-lint
- Running the CI pipeline for every branch
- Stopping the execution of the pipeline after 5 minutes, to prevent a stuck job from costing a fortune