### PR TITLE
refactor(metrics): rename total to unitAmount

### DIFF
--- a/pkg/providers/aws/cloudwatch.go
+++ b/pkg/providers/aws/cloudwatch.go
@@ -71,7 +71,7 @@ func (e *cloudWatchClient) GetEc2Metrics(region awsRegion, cache *awsCache) map[
 			}
 
 			// Build the resource
-			cpu := v1.NewMetric(v1.CPU.String()).SetResourceUnit(cpuMetric.unit).SetTotal(float64(instanceMetadata.coreCount))
+			cpu := v1.NewMetric(v1.CPU.String()).SetResourceUnit(cpuMetric.unit).SetUnitAmount(float64(instanceMetadata.coreCount))
 			cpu.SetUsagePercentage(cpuMetric.value).SetType(cpuMetric.kind)
 
 			// Update the CPU information now

--- a/pkg/providers/gcp/gcp.go
+++ b/pkg/providers/gcp/gcp.go
@@ -196,7 +196,7 @@ func (g *GCP) instanceMetrics(
 			continue
 		}
 
-		m.SetTotal(f)
+		m.SetUnitAmount(f)
 		m.SetLabels(v1.Labels{
 			"id":           instanceID,
 			"name":         instanceName,

--- a/pkg/providers/gcp/gcp_test.go
+++ b/pkg/providers/gcp/gcp_test.go
@@ -85,11 +85,11 @@ func TestGetCPUMetrics(t *testing.T) {
 
 	// TODO see if we can use v1.Metric instead of this
 	type testMetric struct {
-		Name   string
-		Total  float64
-		Type   v1.ResourceType
-		Labels v1.Labels
-		Usage  v1.Percentage
+		Name       string
+		UnitAmount float64
+		Type       v1.ResourceType
+		Labels     v1.Labels
+		Usage      v1.Percentage
 	}
 	testdata := []struct {
 		description         string
@@ -124,8 +124,8 @@ func TestGetCPUMetrics(t *testing.T) {
 						"region":       "europe-west-1",
 						"zone":         "europe-west",
 					},
-					Usage: 1,
-					Total: 2.0000,
+					Usage:      1,
+					UnitAmount: 2.0000,
 				},
 			},
 		},
@@ -178,7 +178,7 @@ func TestGetCPUMetrics(t *testing.T) {
 					assert.Equal(test.expectedResponse[i].Labels, r.Labels())
 					assert.Equal(test.expectedResponse[i].Type, r.Type())
 					assert.Equal(test.expectedResponse[i].Usage, r.Usage())
-					assert.Equal(test.expectedResponse[i].Total, r.Total())
+					assert.Equal(test.expectedResponse[i].UnitAmount, r.UnitAmount())
 				}
 			} else {
 				assert.Equal(

--- a/pkg/types/v1/metric.go
+++ b/pkg/types/v1/metric.go
@@ -19,8 +19,8 @@ type Metric struct {
 	// The resource usage in percentage
 	usage Percentage
 
-	// The total amount
-	total float64
+	// The total amount of unit types
+	unitAmount float64
 
 	// The unit representing this resource
 	unit ResourceUnit
@@ -73,10 +73,10 @@ func (r *Metric) Usage() Percentage {
 	return r.usage
 }
 
-// The resource total
+// The resource amount
 // In case of a virtual machine for example is the total amount of cores
-func (r *Metric) Total() float64 {
-	return r.total
+func (r *Metric) UnitAmount() float64 {
+	return r.unitAmount
 }
 
 // The resource unit
@@ -105,7 +105,7 @@ func (r *Metric) Labels() Labels {
 // Useful for logging or debugging
 func (r *Metric) String() string {
 	// Basic string
-	out := fmt.Sprintf("type:%s name:%s | total:%f %s | usage:%f%%", r.resourceType, r.name, r.total, r.unit, r.usage)
+	out := fmt.Sprintf("type:%s name:%s | amount:%f %s | usage:%f%%", r.resourceType, r.name, r.unitAmount, r.unit, r.usage)
 
 	// if we have emissions show them
 	if r.emissions.value > 0 {
@@ -155,14 +155,14 @@ func (r *Metric) SetUsagePercentage(usage float64) *Metric {
 // Examples:
 // - total amount of core of a VM
 // - disk size
-func (r *Metric) SetTotal(total float64) *Metric {
-	// No reason to have a negative total
-	if total < 0 {
-		total = 0
+func (r *Metric) SetUnitAmount(amount float64) *Metric {
+	// No reason to have a negative amount
+	if amount < 0 {
+		amount = 0
 	}
 
-	// Assign the total
-	r.total = total
+	// Assign the amount
+	r.unitAmount = amount
 
 	// Allows to use it as a builder
 	return r
@@ -192,7 +192,7 @@ func (r *Metric) SetUpdatedAt() *Metric {
 
 // Set the emissions for the resource
 func (r *Metric) SetEmissions(emissions ResourceEmissions) *Metric {
-	// Assign the total
+	// Assign the amount
 	r.emissions = emissions
 
 	// Allows to use it as a builder
@@ -201,7 +201,7 @@ func (r *Metric) SetEmissions(emissions ResourceEmissions) *Metric {
 
 // Set the labels for the resource
 func (r *Metric) SetLabels(labels Labels) *Metric {
-	// Assign the total
+	// Assign the amount
 	r.labels = labels
 
 	// Allows to use it as a builder

--- a/pkg/types/v1/metric_test.go
+++ b/pkg/types/v1/metric_test.go
@@ -12,14 +12,14 @@ func TestResourceFunctionalities(t *testing.T) {
 	assert.NotNil(t, r)
 
 	// Assign the various values to the resource
-	r.SetUsagePercentage(20.54).SetTotal(4.0).SetResourceUnit(Core).SetType(CPU)
+	r.SetUsagePercentage(20.54).SetUnitAmount(4.0).SetResourceUnit(Core).SetType(CPU)
 	r.SetEmissions(NewResourceEmissions(1056.76, GCO2eqkWh))
 	r.SetUpdatedAt()
 
 	// Validate the data
 	assert.Equal(t, r.Name(), "cpu")
 	assert.Equal(t, r.Usage(), Percentage(20.54))
-	assert.Equal(t, r.Total(), float64(4.0))
+	assert.Equal(t, r.UnitAmount(), float64(4.0))
 	assert.Equal(t, r.Type(), CPU)
 	assert.Equal(t, r.Unit(), Core)
 	assert.Equal(t, r.Emissions().Value(), float64(1056.76))

--- a/pkg/types/v1/metrics_test.go
+++ b/pkg/types/v1/metrics_test.go
@@ -11,12 +11,12 @@ func TestMetricsParser(t *testing.T) {
 	cpuResource := NewMetric("cpu")
 	assert.NotNil(t, cpuResource)
 
-	cpuResource.SetUsagePercentage(20.54).SetTotal(4.0)
+	cpuResource.SetUsagePercentage(20.54).SetUnitAmount(4.0)
 	cpuResource.SetType(CPU).SetResourceUnit(Core)
 	cpuResource.SetEmissions(NewResourceEmissions(1056.76, GCO2eqkWh))
 
 	assert.Equal(t, cpuResource.Usage(), Percentage(20.54))
-	assert.Equal(t, cpuResource.Total(), float64(4.0))
+	assert.Equal(t, cpuResource.UnitAmount(), float64(4.0))
 	assert.Equal(t, cpuResource.Unit(), Core)
 	assert.Equal(t, cpuResource.Type(), CPU)
 	assert.Equal(t, cpuResource.emissions.Value(), float64(1056.76))

--- a/pkg/types/v1/service_test.go
+++ b/pkg/types/v1/service_test.go
@@ -16,7 +16,7 @@ func TestServiceOperations(t *testing.T) {
 
 	// Mocking the metric
 	r := NewMetric("cpu")
-	r.SetUsagePercentage(170.4).SetTotal(4.0).SetResourceUnit(Core)
+	r.SetUsagePercentage(170.4).SetUnitAmount(4.0).SetResourceUnit(Core)
 	r.SetEmissions(NewResourceEmissions(1024.57, GCO2eqkWh))
 	r.SetUpdatedAt()
 


### PR DESCRIPTION
In an attempt to describe the value a bit more, change total to unitAmount for the count/amount of units for the resource. For CPU that's core units, and the total count of cores. MEMORY is GB, so the amount of DRAM in GB.