### PR TITLE
Update server lifespace and vCPU

### DIFF
--- a/pkg/calculator/calculator.go
+++ b/pkg/calculator/calculator.go
@@ -8,11 +8,11 @@ import (
 	v1 "github.com/re-cinq/cloud-carbon/pkg/types/v1"
 )
 
-// TODO add links / sources for where numbers and calculations are gathered
-
-// lifespan is the default amount of years a server is in use before being
-// replaced in a datacenter
-const lifespan = 4
+// AWS, GCP and Azure have increased their server lifespan to 6 years (2024)
+// https://sustainability.aboutamazon.com/products-services/the-cloud?energyType=true
+// https://www.theregister.com/2024/01/31/alphabet_q4_2023/#:~:text=Alphabet%20first%20decided%20to%20extend,for%20six%20years%20before%20replacement.
+// https://www.theregister.com/2022/08/02/microsoft_server_life_extension/
+const serverLifespan = 6
 
 type calculate struct {
 	minWatts      float64
@@ -73,7 +73,7 @@ func (c *calculate) embodiedEmissions(interval time.Duration) float64 {
 	// Total Embodied is the total emissions for a server to be produced, including
 	// additional emmissions for added DRAM, CPUs, GPUS, and storage. This is divided
 	// by the expected lifespan of the server to get the annual emissions.
-	annualEmbodied := c.totalEmbodied / lifespan
+	annualEmbodied := c.totalEmbodied / serverLifespan
 
 	// The embodied emissions need to be calculated for the measurement interval, so the
 	// annual emissions further divided to the interval minutes.

--- a/pkg/calculator/calculator.go
+++ b/pkg/calculator/calculator.go
@@ -43,14 +43,14 @@ func (c *calculate) operationalEmissions(metric *v1.Metric, interval time.Durati
 // cpu are the emissions released from the machines the service is
 // running on based on architecture and utilization.
 func (c *calculate) cpu(m *v1.Metric, interval time.Duration) (float64, error) {
-	// Check that number of cores is set
+	// Check that number of vCPUs is set
 	if m.UnitAmount() == 0 {
-		return 0, errors.New("error Cores set to 0, this should never be the case")
+		return 0, errors.New("error vCPUs set to 0, this should never be the case")
 	}
 
-	// vCPUHours is the amount of cores on the machine multiplied by the interval of time
+	// vCPUHours is the amount of vCPUs on the machine multiplied by the interval of time
 	// for 1 hour. For example, if the machine has 4 cores and the interval of time is
-	// 5 minutes: The hourly time is 5/60 (0.083333333) * 4 cores = 0.333333333.
+	// 5 minutes: The hourly time is 5/60 (0.083333333) * 4 vCPUs = 0.333333333.
 	//nolint:unconvert //conversion to minutes does affect calculation
 	vCPUHours := m.UnitAmount() * (float64(interval.Minutes()) / float64(60))
 

--- a/pkg/calculator/calculator_test.go
+++ b/pkg/calculator/calculator_test.go
@@ -204,13 +204,13 @@ func TestCalculateEmbodiedEmissions(t *testing.T) {
 		{
 			name:     "1706.48 total 30 seconds",
 			embodied: 1706.48,
-			expRes:   0.0004058409436834094,
+			expRes:   0.000270560629122273,
 			interval: 30 * time.Second,
 		},
 		{
 			name:     "1706.48 total 5 minutes",
 			embodied: 1706.48,
-			expRes:   0.004058409436834094,
+			expRes:   0.0027056062912227297,
 			interval: 5 * time.Minute,
 		},
 		{
@@ -222,7 +222,7 @@ func TestCalculateEmbodiedEmissions(t *testing.T) {
 		{
 			name:     "large emissions, 1 minute",
 			embodied: 6268.55,
-			expRes:   0.0029816162480974123,
+			expRes:   0.0019877441653982754,
 			interval: 1 * time.Minute,
 		},
 	}

--- a/pkg/calculator/calculator_test.go
+++ b/pkg/calculator/calculator_test.go
@@ -33,7 +33,7 @@ func defaultCalc() *calculate {
 func defaultMetric() *v1.Metric {
 	m := v1.NewMetric("basic")
 	m.SetType(v1.CPU).SetUsage(25)
-	m.SetUnitAmount(4).SetResourceUnit(v1.Core)
+	m.SetUnitAmount(4).SetResourceUnit(v1.VCPU)
 	return m
 }
 
@@ -66,14 +66,14 @@ func TestCalculateCPUEmissions(t *testing.T) {
 			}
 		}(),
 		func() *testcase {
-			// cores not set
+			// vCPUs not set
 			return &testcase{
-				name:      "no cores set",
+				name:      "no vCPUs set",
 				interval:  30 * time.Second,
 				calculate: defaultCalc(),
 				metric:    defaultMetric().SetUnitAmount(0),
 				hasErr:    true,
-				expErr:    "error Cores set to 0, this should never be the case",
+				expErr:    "error vCPUs set to 0, this should never be the case",
 			}
 		}(),
 
@@ -103,9 +103,9 @@ func TestCalculateCPUEmissions(t *testing.T) {
 		}(),
 
 		func() *testcase {
-			// calculate with only a single core
+			// calculate with only a single vCPU
 			return &testcase{
-				name:      "single core",
+				name:      "single vCPU",
 				interval:  30 * time.Second,
 				calculate: defaultCalc(),
 				metric:    defaultMetric().SetUnitAmount(1),
@@ -165,7 +165,7 @@ func TestCalculateCPUEmissions(t *testing.T) {
 
 		func() *testcase {
 			// create a relatively large server with higher
-			// than typical min and max watts, 32 cores, and
+			// than typical min and max watts, 32 vCPUs, and
 			// a utilization of 90%
 			return &testcase{
 				name:     "large server and large workload",

--- a/pkg/providers/aws/cloudwatch.go
+++ b/pkg/providers/aws/cloudwatch.go
@@ -88,7 +88,7 @@ func (e *cloudWatchClient) GetEC2Metrics(ca *cache.Cache, region string, interva
 		}
 
 		s.AddLabel("Name", meta.Name)
-		metric.SetUnitAmount(float64(meta.CoreCount))
+		metric.SetUnitAmount(float64(meta.VCPUCount))
 		s.Metrics().Upsert(&metric)
 
 		local[instanceID] = s
@@ -139,7 +139,7 @@ func (e *cloudWatchClient) getEC2CPU(region string, start, end time.Time, interv
 
 		if len(metric.Values) > 0 {
 			cpu := v1.NewMetric(v1.CPU.String())
-			cpu.SetResourceUnit(v1.Core).SetUsage(metric.Values[0]).SetType(v1.CPU)
+			cpu.SetResourceUnit(v1.VCPU).SetUsage(metric.Values[0]).SetType(v1.CPU)
 			cpu.SetLabels(map[string]string{
 				"instanceID": instanceID,
 			})

--- a/pkg/providers/aws/cloudwatch_test.go
+++ b/pkg/providers/aws/cloudwatch_test.go
@@ -50,7 +50,7 @@ func TestGetMetricsData(t *testing.T) {
 		res, err := client.getEC2CPU(region, start, end, interval)
 		testtools.ExitTest(stubber, t)
 
-		expRes := v1.NewMetric("cpu").SetUsage(float64(.0000123)).SetResourceUnit("core").SetType(v1.CPU)
+		expRes := v1.NewMetric("cpu").SetUsage(float64(.0000123)).SetResourceUnit("vCPU").SetType(v1.CPU)
 		expRes.SetLabels(map[string]string{
 			"instanceID": "i-00123456789",
 		})

--- a/pkg/providers/aws/ec2.go
+++ b/pkg/providers/aws/ec2.go
@@ -77,7 +77,7 @@ func (e *ec2Client) Refresh(ctx context.Context, ca *cache.Cache, region string)
 					Region:      region,
 					Kind:        string(instance.InstanceType),
 					Lifecycle:   string(instance.InstanceLifecycle),
-					CoreCount:   int(aws.ToInt32(instance.CpuOptions.CoreCount)),
+					VCPUCount:   int(aws.ToInt32(instance.CpuOptions.CoreCount) * aws.ToInt32(instance.CpuOptions.ThreadsPerCore)),
 					LastUpdated: time.Now().UTC(),
 				},
 				cache.DefaultExpiration,

--- a/pkg/providers/gcp/gcp.go
+++ b/pkg/providers/gcp/gcp.go
@@ -246,7 +246,7 @@ func (g *GCP) Refresh(ctx context.Context, project string) {
 					Service:     service,
 					Kind:        getValueFromURL(instance.GetMachineType()),
 					Lifecycle:   instance.GetScheduling().GetProvisioningModel(),
-					CoreCount:   0,
+					VCPUCount:   0,
 					LastUpdated: time.Now().UTC(),
 				}, cache.DefaultExpiration)
 			}

--- a/pkg/types/v1/cache_store.go
+++ b/pkg/types/v1/cache_store.go
@@ -18,8 +18,8 @@ type Resource struct {
 	// For example spot, reserved
 	Lifecycle string
 
-	// Amount of cores
-	CoreCount int
+	// Amount of vCPUs
+	VCPUCount int
 
 	// The instance kind for example
 	Kind string

--- a/pkg/types/v1/enum_resource_units.go
+++ b/pkg/types/v1/enum_resource_units.go
@@ -14,7 +14,7 @@ var ErrParsingResourceUnits = errors.New("unsupported ResourceUnits")
 // ResourceUnits Lookup map for listing all the supported resource units
 // as well as deserializing them
 var ResourceUnits = map[string]ResourceUnit{
-	coreString: Core,
+	vCPUString: VCPU,
 	kbString:   Kb,
 	mbString:   Mb,
 	gbString:   Gb,
@@ -27,8 +27,8 @@ var ResourceUnits = map[string]ResourceUnit{
 
 const (
 
-	// CPU Core
-	Core ResourceUnit = coreString
+	// vCPU
+	VCPU ResourceUnit = vCPUString
 
 	// -------------------------------------------
 	// Used for both Ram and Disk
@@ -64,7 +64,7 @@ const (
 	Tbs ResourceUnit = tbsString
 
 	// Static strings
-	coreString = "core"
+	vCPUString = "vCPU"
 	kbString   = "kb"
 	mbString   = "mb"
 	gbString   = "gb"

--- a/pkg/types/v1/enum_resource_units_test.go
+++ b/pkg/types/v1/enum_resource_units_test.go
@@ -13,12 +13,12 @@ type testResourceUnitStruct struct {
 
 func TestResourceUnitParser(t *testing.T) {
 	testData := `{
-		"unit": "core"
+		"unit": "vCPU"
 	}`
 
 	var testResourceUnit testResourceUnitStruct
 	err := json.Unmarshal([]byte(testData), &testResourceUnit)
 	assert.Nil(t, err)
 
-	assert.Equal(t, testResourceUnit.TestResourceUnit, Core)
+	assert.Equal(t, testResourceUnit.TestResourceUnit, VCPU)
 }

--- a/pkg/types/v1/instance_test.go
+++ b/pkg/types/v1/instance_test.go
@@ -16,7 +16,7 @@ func TestInstanceOperations(t *testing.T) {
 
 	// Mocking the metric
 	r := NewMetric("cpu")
-	r.SetUsage(170.4).SetUnitAmount(4.0).SetResourceUnit(Core)
+	r.SetUsage(170.4).SetUnitAmount(4.0).SetResourceUnit(VCPU)
 	r.SetEmissions(NewResourceEmission(1024.57, GCO2eqkWh))
 	r.SetUpdatedAt()
 

--- a/pkg/types/v1/metric.go
+++ b/pkg/types/v1/metric.go
@@ -74,13 +74,13 @@ func (r *Metric) Usage() float64 {
 }
 
 // The resource amount
-// In case of a virtual machine for example is the total amount of cores
+// In case of a virtual machine for example is the total amount of vCPUs
 func (r *Metric) UnitAmount() float64 {
 	return r.unitAmount
 }
 
 // The resource unit
-// - In case of a cpu is the amount of cores
+// - In case of a cpu is the amount of vCPUs
 // - In case of ram is a multiple of bytes
 func (r *Metric) Unit() ResourceUnit {
 	return r.unit
@@ -146,7 +146,7 @@ func (r *Metric) SetUsage(u float64) *Metric {
 
 // Adds the total amount of the resource:
 // Examples:
-// - total amount of core of a VM
+// - total amount of vCPUs of a VM
 // - disk size
 func (r *Metric) SetUnitAmount(amount float64) *Metric {
 	// No reason to have a negative amount
@@ -163,7 +163,7 @@ func (r *Metric) SetUnitAmount(amount float64) *Metric {
 
 // Adds the resource unit
 // Examples:
-// - cores: in case of a CPU
+// - vCPUs: in case of a CPU
 // - Gb: in case of a Disk
 // - Gb: in case of Ram
 func (r *Metric) SetResourceUnit(unit ResourceUnit) *Metric {

--- a/pkg/types/v1/metric_test.go
+++ b/pkg/types/v1/metric_test.go
@@ -12,7 +12,7 @@ func TestResourceFunctionalities(t *testing.T) {
 	assert.NotNil(t, r)
 
 	// Assign the various values to the resource
-	r.SetUsage(20.54).SetUnitAmount(4.0).SetResourceUnit(Core).SetType(CPU)
+	r.SetUsage(20.54).SetUnitAmount(4.0).SetResourceUnit(VCPU).SetType(CPU)
 	r.SetEmissions(NewResourceEmission(1056.76, GCO2eqkWh))
 	r.SetUpdatedAt()
 
@@ -21,7 +21,7 @@ func TestResourceFunctionalities(t *testing.T) {
 	assert.Equal(t, r.Usage(), 20.54)
 	assert.Equal(t, r.UnitAmount(), float64(4.0))
 	assert.Equal(t, r.Type(), CPU)
-	assert.Equal(t, r.Unit(), Core)
+	assert.Equal(t, r.Unit(), VCPU)
 	assert.Equal(t, r.Emissions().Value(), float64(1056.76))
 	assert.Equal(t, r.Emissions().Unit(), GCO2eqkWh)
 

--- a/pkg/types/v1/metrics_test.go
+++ b/pkg/types/v1/metrics_test.go
@@ -12,12 +12,12 @@ func TestMetricsParser(t *testing.T) {
 	assert.NotNil(t, cpuResource)
 
 	cpuResource.SetUsage(20.54).SetUnitAmount(4.0)
-	cpuResource.SetType(CPU).SetResourceUnit(Core)
+	cpuResource.SetType(CPU).SetResourceUnit(VCPU)
 	cpuResource.SetEmissions(NewResourceEmission(1056.76, GCO2eqkWh))
 
 	assert.Equal(t, cpuResource.Usage(), 20.54)
 	assert.Equal(t, cpuResource.UnitAmount(), float64(4.0))
-	assert.Equal(t, cpuResource.Unit(), Core)
+	assert.Equal(t, cpuResource.Unit(), VCPU)
 	assert.Equal(t, cpuResource.Type(), CPU)
 	assert.Equal(t, cpuResource.emissions.Value(), float64(1056.76))
 	assert.Equal(t, cpuResource.emissions.Unit(), GCO2eqkWh)


### PR DESCRIPTION
* All cloud provider server lifespan has been updated to 6 years
* To calculate CPU energy consumption, vCPU is used, not cores. Update to store that metric variable and get it from server information from providers.
* For GCP this is accessed from the Query. 
* For AWS, it can be calculated by getting the instance Cores and multiplying by Threads Per Core